### PR TITLE
Add pull request builds to workflow

### DIFF
--- a/.github/workflows/jekyll-deploy.yml
+++ b/.github/workflows/jekyll-deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1' # Use Ruby version from .ruby-version or specify directly
+          ruby-version-file: '.ruby-version' # Use Ruby version from .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Setup Pages

--- a/.github/workflows/jekyll-deploy.yml
+++ b/.github/workflows/jekyll-deploy.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: ["main"]
 
+  # Runs on pull requests targeting the main branch
+  pull_request:
+    branches: ["main"]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -44,10 +48,14 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Upload artifact
+        # Only upload artifact for deployment on push to main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:
+    # Only deploy on push to main, not on pull requests
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The workflow now builds on pull requests to main for testing, but only deploys when pushing directly to main. This allows PRs to verify the site builds correctly before merging.