### PR TITLE
Remove Slack contact from system

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -6,18 +6,7 @@
       </div>
     </div>
     <div class="row text-center">
-      <div class="col-md-4">
-                    <span class="fa-stack fa-4x">
-                        <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                        <i class="fa fa-slack fa-stack-1x fa-inverse"></i>
-                    </span>
-        <h4 class="section-heading">Slack</h4>
-        <p class="text-muted">Primárně komunikujeme na Slacku.<br>(Pozvánku pošleme na požádání.)</p>
-        <p>
-          <a href="https://cowosedlice.slack.com" class="btn btn-primary" role="button">Slack</a>
-        </p>
-      </div>
-      <div class="col-md-4">
+      <div class="col-md-6">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-map-marker fa-stack-1x fa-inverse"></i>
@@ -28,7 +17,7 @@
           Novosedlice<br>
           417 31</p>
       </div>
-      <div class="col-md-4">
+      <div class="col-md-6">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-mobile fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
Removed the Slack contact method from the contact page, leaving only in-person and phone contact options. Updated grid layout from 3 columns to 2 columns for better visual balance.