### PR TITLE
Review external documentation file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -125,4 +125,10 @@ address:
 # Build settings
 markdown: kramdown
 permalink: pretty
+exclude:
+  - CLAUDE.md
+  - Gemfile
+  - Gemfile.lock
+  - README.md
+  - vendor/
 


### PR DESCRIPTION
Add exclude directive to _config.yml to prevent CLAUDE.md (project documentation) from being included in the Jekyll build. Also exclude other development files like Gemfile, README.md, and vendor directory for cleaner public deployment.