### PR TITLE
Add email contact option to contact section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ All plans include: WiFi, printer, PC, kitchen, fridge, coffee maker, etc.
 Contact information:
 - Phone: Radim Klaška at +420 605 271 780
 - Physical address: Míru 218, Novosedlice, 417 31
-- Email: radek@cowosedlice.cz (configured in `_config.yml`)
+- Email: radim@cowosedlice.cz (configured in `_config.yml`)
 - Social media links (Facebook, GitHub) in footer
 
 ### 9. Footer (`_includes/footer.html`)
@@ -166,7 +166,7 @@ The `_config.yml` file contains all site configuration and content:
 ```yaml
 url: http://www.cowosedlice.cz
 title: Cowosedlice.cz - sdílená kancelář v Novosedlicích u Teplic
-email: radek@cowosedlice.cz
+email: radim@cowosedlice.cz
 description: "Cowosedlice jsou tu pro ty, kterým nevyhovuje práce z domova..."
 
 # Content sections are configured with YAML data structures
@@ -382,7 +382,7 @@ The site uses Bootstrap 3.x and jQuery 1.x, supporting:
 
 - **Website**: http://www.cowosedlice.cz/
 - **Phone**: Radim Klaška at +420 605 271 780
-- **Email**: radek@cowosedlice.cz
+- **Email**: radim@cowosedlice.cz
 - **Facebook**: https://www.facebook.com/cowosedlice/
 - **GitHub**: https://github.com/cowosedlice
 - **Address**: Míru 218, Novosedlice, 417 31

--- a/_config.yml
+++ b/_config.yml
@@ -81,7 +81,7 @@ people:
   position: Ještě máme pár volných míst.
   social:
     - title: plus
-      url: mailto:radek@cowosedlice.cz
+      url: contact
 
 
 - name: Volné místo
@@ -89,15 +89,7 @@ people:
   position: Ještě máme pár volných míst.
   social:
     - title: plus
-      url: mailto:radek@cowosedlice.cz
-
-
-- name: Volné místo
-  pic: 999
-  position: Ještě máme pár volných míst. 
-  social:
-    - title: plus
-      url: mailto:radek@cowosedlice.cz
+      url: contact
 
 
 - name: Volné místo
@@ -105,7 +97,15 @@ people:
   position: Ještě máme pár volných míst.
   social:
     - title: plus
-      url: mailto:radek@cowosedlice.cz
+      url: contact
+
+
+- name: Volné místo
+  pic: 999
+  position: Ještě máme pár volných míst.
+  social:
+    - title: plus
+      url: contact
 
 
 # Social networks usernames (many more available: google-plus, flickr, dribbble, pinterest, instagram, tumblr, linkedin, etc.)

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ baseurl:
 # Site settings
 title: Cowosedlice.cz - sdílená kancelář v Novosedlicích u Teplic
 title-visible: COWOSEDLICE
-email: radek@cowosedlice.cz
+email: radim@cowosedlice.cz
 description: "Cowosedlice jsou tu pro ty, kterým nevyhovuje práce z domova anebo pro ty, kteří zkrátka jen chtějí zkusit změnu."
 
 # About section

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -6,7 +6,7 @@
       </div>
     </div>
     <div class="row text-center">
-      <div class="col-md-6">
+      <div class="col-md-4">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-map-marker fa-stack-1x fa-inverse"></i>
@@ -17,7 +17,7 @@
           Novosedlice<br>
           417 31</p>
       </div>
-      <div class="col-md-6">
+      <div class="col-md-4">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-mobile fa-stack-1x fa-inverse"></i>
@@ -25,6 +25,15 @@
         <h4 class="section-heading">Telefonicky</h4>
         <p class="text-muted">Na telefonu je <strong>Radim Klaška</strong>:</p>
         <p class="text-primary"><a href="tel:+420605271780">+420605271780</a></p>
+      </div>
+      <div class="col-md-4">
+                    <span class="fa-stack fa-4x">
+                        <i class="fa fa-circle fa-stack-2x text-primary"></i>
+                        <i class="fa fa-envelope fa-stack-1x fa-inverse"></i>
+                    </span>
+        <h4 class="section-heading">E-mailem</h4>
+        <p class="text-muted">Napište nám na:</p>
+        <p class="text-primary"><a href="mailto:{{ site.email }}">{{ site.email }}</a></p>
       </div>
     </div>
   </div>

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -17,9 +17,15 @@
                         <ul class="list-inline social-buttons">
                             {% for network in member.social %}
                             <li>
+                                {% if network.url == "contact" %}
+                                <a href="mailto:{{ site.email }}">
+                                    <i class="fa fa-{{ network.title }}"></i>
+                                </a>
+                                {% else %}
                                 <a href="{{ network.url }}">
                                     <i class="fa fa-{{ network.title }}"></i>
                                 </a>
+                                {% endif %}
                             </li>
                             {% endfor %}
 


### PR DESCRIPTION
## Summary
- Added email as a third contact option in the contact section
- Updated layout from 2 columns to 3 columns for address, phone, and email
- Email address dynamically pulled from `site.email` variable in `_config.yml`
- Updated email address from `radek@cowosedlice.cz` to `radim@cowosedlice.cz`

## Changes Made
1. **_config.yml**: Updated email address to `radim@cowosedlice.cz`
2. **_includes/contact.html**: 
   - Changed grid from `col-md-6` to `col-md-4` (3 columns)
   - Added email section with envelope icon (`fa-envelope`)
   - Email uses `{{ site.email }}` variable (follows Jekyll best practices)

## Preview
The contact section now displays three contact options side by side:
- **Osobně** (Address) with map marker icon
- **Telefonicky** (Phone) with mobile icon
- **E-mailem** (Email) with envelope icon ✨

🤖 Generated with [Claude Code](https://claude.com/claude-code)