### PR TITLE
Update pricing tiers for coworking space services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,9 +143,9 @@ Interactive Google Maps integration showing location:
 
 ### 7. Pricing Section (`_includes/price.html`)
 Three pricing tiers:
-- **Daily rate**: 210 Kč per day (2 free trial days for new members)
-- **Medium plan**: 1540 Kč/month (10 working days, 8:00-17:00, flexible seating)
-- **Large plan**: 2450 Kč/month (24/7 access, dedicated workspace)
+- **Daily rate**: 300 Kč per day (2 free trial days for new members)
+- **Medium plan**: 2000 Kč/month (10 working days, 8:00-17:00, flexible seating)
+- **Large plan**: 3500 Kč/month (24/7 access, dedicated workspace)
 
 All plans include: WiFi, printer, PC, kitchen, fridge, coffee maker, etc.
 

--- a/_config.yml
+++ b/_config.yml
@@ -39,17 +39,17 @@ history:
 price-heading: Ceník
 price-subheading: Ať už máte malý nebo velký tarif, vždy budete mít možnost využívat všeho, co se v cowosedlicích nachází. Wifi, tiskárna, cowosedlické PC, kuchyňka, lednice, kávovar atd. A stálí členové mají samozřejmě své vlastní vyhrazené pracovní místo.
 price:
-- tariff: 210Kč denně
+- tariff: 300Kč denně
   pic: battery-quarter
   desc-title: Malý tarif
-  desc: Pro nové členy jsou 2 dny zdarma, jinak 210Kč za každý započatý den.
+  desc: Pro nové členy jsou 2 dny zdarma, jinak 300Kč za každý započatý den.
 
-- tariff: 1540Kč měsíčně
+- tariff: 2000Kč měsíčně
   pic: battery-three-quarters
   desc-title: Střední tarif
   desc: Pokrývá 10 pracovních dní od 8:00 do 17:00 a můžete pracovat tam, kde je zrovna volno.
 
-- tariff: 2450Kč měsíčně
+- tariff: 3500Kč měsíčně
   pic: battery-full
   desc-title: Velký tarif
   desc: Přístup 24/7 a možnost zřízení vlastního pracovního místa.


### PR DESCRIPTION
## Summary
Updated the pricing structure for all three coworking space membership tiers to reflect new rates.

## Changes
- **Small tariff (daily)**: Increased from 210Kč to 300Kč per day
  - Updated both the tariff display and description text
- **Medium tariff (monthly)**: Increased from 1540Kč to 2000Kč per month
  - Covers 10 business days from 8:00 to 17:00
- **Large tariff (monthly)**: Increased from 2450Kč to 3500Kč per month
  - Provides 24/7 access with dedicated workspace option

All pricing information in the configuration file has been consistently updated across both the tariff labels and their corresponding descriptions.

https://claude.ai/code/session_011yZy4xxg5RhDfYhKtMZMiZ