### PR TITLE
Restrict @claude trigger to org members and collaborators

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,25 @@ on:
 
 jobs:
   claude:
+    # Only trigger for org members/collaborators to prevent drive-by `@claude`
+    # invocations from random GitHub users burning OAuth credits on a public repo.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        (github.event.review.author_association == 'OWNER' ||
+         github.event.review.author_association == 'MEMBER' ||
+         github.event.review.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        (github.event.issue.author_association == 'OWNER' ||
+         github.event.issue.author_association == 'MEMBER' ||
+         github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Gate every event branch in `.github/workflows/claude.yml` on `author_association` being `OWNER`, `MEMBER`, or `COLLABORATOR`.
- Prevents drive-by `@claude` invocations from random GitHub users on this public repo from burning OAuth credits on `CLAUDE_CODE_OAUTH_TOKEN`.
- The fork-PR approval gate (org setting "Require approval for all external contributors") does not cover `issue_comment` / `pull_request_review_comment` / `issues` / `pull_request_review` events — those still ran with secrets for anyone who could comment. This filter closes that gap.

## Test plan
- [ ] After merge, comment `@claude ping` from a non-member account on an issue/PR — workflow should not run (the conditional skips it).
- [ ] Comment `@claude ping` as the repo owner — workflow should run as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)